### PR TITLE
Update Master Layout Window Management (Breaking Changes)

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -73,7 +73,7 @@ dwindle {
 
 # See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
 master {
-    new_is_master = true
+    new_status = master
 }
 
 


### PR DESCRIPTION
Use `new_status` in favor of `new_is_master`

For more details: https://github.com/hyprwm/Hyprland/commit/89f795da98cc53faf7e3a683d8c189aa24986267